### PR TITLE
Canvas context improvements

### DIFF
--- a/demo/index.tsx
+++ b/demo/index.tsx
@@ -32,7 +32,7 @@ const Page: CXComponent = () => {
   const reactive = useReactive({ isMounted: true, offset: getOffset() });
 
   useLoop(() => {
-    // reactive.offset = getOffset();
+    reactive.offset = getOffset();
   });
 
   useOnMount(() => {

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1"
     />
-    <title>RCX - Reactive Canvas XML</title>
+    <title>RCX - Reactive JSX-based library for creating HTML5 canvas applications</title>
     <style type="text/css">
       html,
       body {

--- a/src/components/canvas/context.ts
+++ b/src/components/canvas/context.ts
@@ -1,4 +1,6 @@
 import { createContext } from '../../create-context.ts';
-import type { CanvasContext } from '../../types.ts';
+import type { CXCanvasContext, CXRenderingContext } from '../../types.ts';
 
-export const canvasContext = createContext<CanvasContext>();
+export const canvasContext = createContext<CXCanvasContext>();
+
+export const renderingContext = createContext<CXRenderingContext>();

--- a/src/create-context.ts
+++ b/src/create-context.ts
@@ -27,7 +27,7 @@ export const createContext = <T extends AnyObject>(name?: string) => {
       );
     }
 
-    return currentNode.context[symbol] as T | undefined;
+    return currentNode.context[symbol] as Readonly<T> | undefined;
   };
 
   const Provider: CXComponent<ProviderProps<T>> = ({ children, value }) => {

--- a/src/hooks/use-canvas-context.ts
+++ b/src/hooks/use-canvas-context.ts
@@ -1,5 +1,11 @@
 import { canvasContext } from '../components/canvas/context.ts';
-import type { CanvasContext } from '../types.ts';
 
-export const useCanvasContext = () =>
-  canvasContext.useInject() as CanvasContext;
+export const useCanvasContext = () => {
+  const context = canvasContext.useInject();
+
+  if (!context) {
+    throw new Error('useCanvasContext must be used inside a Canvas component');
+  }
+
+  return context;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ export * from './hooks/use-loop.ts';
 export * from './hooks/use-on.ts';
 export * from './components/canvas/index.ts';
 export * from './components/rectangle.ts';
+export * from './create-context.ts';

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,12 +1,10 @@
-import { canvasContext } from './components/canvas/context.ts';
+import { renderingContext } from './components/canvas/context.ts';
 import { emitter } from './emitter.ts';
-import { getRecommendedPixelRatio } from './get-recommended-pixel-ratio.ts';
 import { cxGlobal } from './global.ts';
 import type {
   AnyCXElement,
   AnyCXNode,
   AnyObject,
-  CanvasContext,
   CXChild,
   CXChildren,
   CXRenderingContext,
@@ -146,9 +144,8 @@ const getMatchingChildNext = (
 
 const renderElement = (
   element: AnyCXElement,
-  renderingContext: CXRenderingContext,
+  renderingContextState: CXRenderingContext,
   prevNode: AnyCXNode | undefined,
-  initialCanvasContext?: CanvasContext,
   parentContext?: AnyObject
 ): AnyCXNode => {
   const node = updateNode(element, prevNode);
@@ -156,9 +153,7 @@ const renderElement = (
   cxGlobal.currentNode = node;
   cxGlobal.hookIndex = 0;
 
-  if (initialCanvasContext) {
-    canvasContext.useProvide(initialCanvasContext);
-  }
+  renderingContext.useProvide(renderingContextState);
 
   node.context = {
     ...parentContext,
@@ -213,13 +208,12 @@ const renderElement = (
 
       return renderElement(
         nextRendered,
-        renderingContext,
+        renderingContextState,
         !!prevRendered &&
           typeof prevRendered === 'object' &&
           !isArray(prevRendered)
           ? prevRendered
           : undefined,
-        undefined,
         node.context
       );
     }
@@ -237,7 +231,7 @@ const renderElement = (
 
   node.hooks.forEach((hook) => {
     if (hook.type === 'useRenderBeforeChildren') {
-      hook.value(renderingContext);
+      hook.value(renderingContextState);
     }
   });
 
@@ -245,7 +239,7 @@ const renderElement = (
 
   node.hooks.forEach((hook) => {
     if (hook.type === 'useRenderAfterChildren') {
-      hook.value(renderingContext);
+      hook.value(renderingContextState);
     }
   });
 
@@ -257,7 +251,7 @@ export const render = (element: AnyCXElement, container: HTMLElement) => {
   const ctx2d = canvas.getContext('2d');
 
   if (!ctx2d) {
-    const errorMessage = 'CanvasRenderingContext2D not supported' as const;
+    const errorMessage = 'CanvasRenderingContext2D not supported';
 
     if (window.console && typeof window.console.error === 'function') {
       // eslint-disable-next-line no-console
@@ -269,21 +263,7 @@ export const render = (element: AnyCXElement, container: HTMLElement) => {
     };
   }
 
-  const renderingContext = { canvas, ctx2d };
-
-  const pixelRatio = getRecommendedPixelRatio();
-
-  const initialCanvasContext: CanvasContext = {
-    ...renderingContext,
-    props: {
-      width: canvas.width,
-      height: canvas.height,
-      pixelRatio,
-    },
-  };
-
-  canvas.width = canvas.clientWidth * pixelRatio;
-  canvas.height = canvas.clientHeight * pixelRatio;
+  const renderingContextState = { canvas, ctx2d };
 
   let raf: number | undefined;
   let rootNode: AnyCXNode | undefined;
@@ -296,13 +276,7 @@ export const render = (element: AnyCXElement, container: HTMLElement) => {
     raf = window.requestAnimationFrame(() => {
       // eslint-disable-next-line no-self-assign
       canvas.width = canvas.width;
-      ctx2d.scale(pixelRatio, pixelRatio);
-      rootNode = renderElement(
-        element,
-        renderingContext,
-        rootNode,
-        initialCanvasContext
-      );
+      rootNode = renderElement(element, renderingContextState, rootNode);
     });
   };
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -150,15 +150,14 @@ const renderElement = (
 ): AnyCXNode => {
   const node = updateNode(element, prevNode);
 
+  node.context = {
+    ...parentContext,
+  };
+
   cxGlobal.currentNode = node;
   cxGlobal.hookIndex = 0;
 
   renderingContext.useProvide(renderingContextState);
-
-  node.context = {
-    ...parentContext,
-    ...node.context,
-  };
 
   node.rendered = element.type(element.props);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,7 +82,7 @@ export type PropsWithChildren<P extends AnyObject> = Omit<P, 'children'> & {
   children?: CXChildren;
 };
 
-export interface CanvasContext {
+export interface CXCanvasContext {
   readonly props: Required<Omit<CanvasProps, 'children'>>;
   readonly canvas: Omit<HTMLCanvasElement, 'width' | 'height'>;
   readonly ctx2d: CanvasRenderingContext2D;


### PR DESCRIPTION
- Update `index.html` title
- Provide rendering context separately from canvas context
- Canvas must be rendered to provide canvas context
- Fix old node context overriding parent context
- Make context objects readonly
- Rename `CXCanvasContext`