### PR TITLE
Fix auto imports

### DIFF
--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": true,
+    "module": "ESNext",
+    "paths": {
+      "@blinkorb/rcx": ["../src/index.ts"],
+      "@blinkorb/rcx/canvas": ["../src/components/canvas/index.ts"],
+      "@blinkorb/rcx/*": ["../src/*"]
+    }
+  },
+  "include": ["./*", "../src/*"]
+}

--- a/scripts/prep-package.js
+++ b/scripts/prep-package.js
@@ -24,5 +24,6 @@ const modifiedJson = {
 
 writeFileSync(
   resolve(cwd, '../dist/package.json'),
-  JSON.stringify(modifiedJson, null, 2)
+  JSON.stringify(modifiedJson, null, 2),
+  'utf-8'
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export * from './types.ts';
-export * from './internal/index.ts';
+export * from './render.ts';
 export * from './hooks/index.ts';
 export * from './components/index.ts';
 export * from './context/index.ts';

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -1,1 +1,0 @@
-export { render } from './render.ts';

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,4 +1,6 @@
-import { renderingContext } from '../components/canvas/context.ts';
+import { renderingContext } from './components/canvas/context.ts';
+import { emitter } from './internal/emitter.ts';
+import { cxGlobal } from './internal/global.ts';
 import type {
   AnyObject,
   NestedArray,
@@ -7,10 +9,8 @@ import type {
   RCXElementAny,
   RCXNodeAny,
   RCXRenderingContext,
-} from '../types.ts';
-import { isArray } from '../utils/type-guards.ts';
-import { emitter } from './emitter.ts';
-import { cxGlobal } from './global.ts';
+} from './types.ts';
+import { isArray } from './utils/type-guards.ts';
 
 const getCanvasElement = (container: HTMLElement) => {
   if (container instanceof HTMLCanvasElement) {

--- a/tsb.config.ts
+++ b/tsb.config.ts
@@ -4,7 +4,7 @@ const config: Config = {
   indexHTMLPath: 'demo/index.html',
   main: 'demo/index.tsx',
   outDir: 'build',
-  tsconfigPath: 'tsconfig.dev.json',
+  tsconfigPath: 'demo/tsconfig.json',
   host: 'localhost',
 };
 

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "sourceMap": true,
-    "module": "ESNext"
-  },
-  "include": ["demo/*", "src/*"]
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,12 +18,7 @@
     "target": "ESNext",
     "module": "NodeNext",
     "jsx": "react-jsx",
-    "jsxImportSource": "@blinkorb/rcx",
-    "paths": {
-      "@blinkorb/rcx": ["./src/index.ts"],
-      "@blinkorb/rcx/canvas": ["./src/components/canvas/index.ts"],
-      "@blinkorb/rcx/*": ["./src/*"]
-    }
+    "jsxImportSource": "@blinkorb/rcx"
   },
   "include": ["demo/*", "src/*", "jest.config.ts"]
 }


### PR DESCRIPTION
- Move demo `tsconfig.json` into `demo` directory.
- Only apply path aliases in demo tsconfig
- Move `render` function outside of `internal` dir
- Don't export `internal` dir
- Add explicit encoding to dist version of `package.json`