### PR TITLE
Create root and handle rerenders

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,15 @@ const App = () => {
 You can then render this component using the `render` function. The render function's second argument is the DOM node where you would like the canvas to appear. If the node is already a canvas RCX will render to that canvas, otherwise it will add a canvas within that node.
 
 ```tsx
-import { render } from '@blinkorb/rcx';
+import { createRoot } from '@blinkorb/rcx';
 
-render(<App />, document.body);
+const root = createRoot(document.body);
+
+if ('error' in root) {
+  console.error(root.error);
+} else {
+  root.render(<App />, document.body);
+}
 ```
 
 ### Basic Components

--- a/README.md
+++ b/README.md
@@ -433,7 +433,9 @@ You can tell TypeScript to treat your RCX components differently (using the JSX 
 
 ### Rendering RCX Components Within React
 
-You can render an RCX component within a React app by getting a `ref` to a canvas node and rendering/unmounting the RCX tree at this node within a `useEffect`.
+This documentation wil be updated after the latest release has been thoroughly tested.
+
+<!-- You can render an RCX component within a React app by getting a `ref` to a canvas node and rendering/unmounting the RCX tree at this node within a `useEffect`.
 
 Make sure you're importing the correct `jsx` function from RCX.
 
@@ -463,4 +465,4 @@ const ReactComponent = () => {
 
   return <canvas ref={setCanvas} />;
 };
-```
+``` -->

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ const root = createRoot(document.body);
 if ('error' in root) {
   console.error(root.error);
 } else {
-  root.render(<App />, document.body);
+  root.render(<App />);
 }
 ```
 

--- a/demo/index.tsx
+++ b/demo/index.tsx
@@ -4,6 +4,7 @@ import {
   Canvas,
   Circle,
   Clip,
+  createRoot,
   Ellipse,
   Line,
   Path,
@@ -11,7 +12,6 @@ import {
   RCXComponent,
   Rectangle,
   RectangleProps,
-  render,
   resolveStyles,
   Rotate,
   Scale,
@@ -371,4 +371,13 @@ const App = () => {
   );
 };
 
-render(<App />, document.body);
+const root = createRoot(document.body);
+
+if ('error' in root) {
+  if (window.console && typeof window.console.error === 'function') {
+    // eslint-disable-next-line no-console
+    console.error(root.error);
+  }
+} else {
+  root.render(<App />);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blinkorb/rcx",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blinkorb/rcx",
-      "version": "0.0.3",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@jakesidsmith/tsb": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blinkorb/rcx",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Reactive JSX-based library for creating HTML5 canvas applications",
   "publishConfig": {
     "access": "public"

--- a/src/internal/emitter.ts
+++ b/src/internal/emitter.ts
@@ -11,8 +11,11 @@ class Emitter<T extends AnyObject> {
   } = {};
 
   public on = <K extends keyof T>(event: K, handler: Handler<T, K>) => {
-    this.handlers[event] = this.handlers[event] || [];
-    this.handlers[event]?.push(handler);
+    this.handlers[event] = this.handlers[event] ?? [];
+
+    if (!this.handlers[event].includes(handler)) {
+      this.handlers[event].push(handler);
+    }
 
     return () => this.off(event, handler);
   };

--- a/src/render.ts
+++ b/src/render.ts
@@ -3,6 +3,7 @@ import { emitter } from './internal/emitter.ts';
 import { cxGlobal } from './internal/global.ts';
 import type {
   AnyObject,
+  CreateRootResult,
   NestedArray,
   RCXChild,
   RCXChildren,
@@ -245,7 +246,7 @@ const renderElement = (
   return node;
 };
 
-export const render = (element: RCXElementAny, container: HTMLElement) => {
+export const createRoot = (container: HTMLElement): CreateRootResult => {
   const canvas = getCanvasElement(container);
   const ctx2d = canvas.getContext('2d');
 
@@ -264,6 +265,7 @@ export const render = (element: RCXElementAny, container: HTMLElement) => {
 
   const renderingContextState = { canvas, ctx2d };
 
+  let rootElement: RCXElementAny | undefined;
   let raf: number | undefined;
   let rootNode: RCXNodeAny | undefined;
 
@@ -275,13 +277,13 @@ export const render = (element: RCXElementAny, container: HTMLElement) => {
     raf = window.requestAnimationFrame(() => {
       // eslint-disable-next-line no-self-assign
       canvas.width = canvas.width;
-      rootNode = renderElement(element, renderingContextState, rootNode);
+      if (rootElement) {
+        rootNode = renderElement(rootElement, renderingContextState, rootNode);
+      } else {
+        rootNode = undefined;
+      }
     });
   };
-
-  renderRoot();
-
-  emitter.on('render', renderRoot);
 
   const unmount = () => {
     if (typeof raf === 'number') {
@@ -292,8 +294,17 @@ export const render = (element: RCXElementAny, container: HTMLElement) => {
 
     if (!(container instanceof HTMLCanvasElement)) {
       container.removeChild(canvas);
+      rootElement = undefined;
     }
   };
 
-  return unmount;
+  return {
+    render: (element: RCXElementAny) => {
+      rootElement = element;
+      renderRoot();
+
+      emitter.on('render', renderRoot);
+    },
+    unmount,
+  };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,3 +149,14 @@ export interface RCXColorStop {
 }
 
 export type RCXFillOrStrokeStyle = string | CanvasGradient;
+
+export interface CreateRootFailure {
+  error: string;
+}
+
+export interface CreateRootSuccess {
+  render: (element: RCXElementAny) => void;
+  unmount: () => void;
+}
+
+export type CreateRootResult = CreateRootFailure | CreateRootSuccess;


### PR DESCRIPTION
Bump version to `0.1.0`

This version has breaking changes.

`render` function has been replaced with a `createRoot` function that returns `render` and `unmount` functions.