### PR TITLE
Safe global access

### DIFF
--- a/workspaces/eslint-config-rcx-dev/src/eslint.config.js
+++ b/workspaces/eslint-config-rcx-dev/src/eslint.config.js
@@ -69,6 +69,8 @@ export default defineConfig([
       ],
       'no-restricted-globals': [
         'error',
+        'error',
+        'window',
         'URL',
         'history',
         'dispatchEvent',

--- a/workspaces/rcx-react/src/useRCXInReact.ts
+++ b/workspaces/rcx-react/src/useRCXInReact.ts
@@ -36,7 +36,10 @@ export const useRCXInReact = <C extends RCXComponent<P>, P extends AnyObject>(
         rootRef.current = null;
         setRoot(null);
 
-        if (window.console && typeof window.console.error === 'function') {
+        if (
+          globalThis.console &&
+          typeof globalThis.console.error === 'function'
+        ) {
           // eslint-disable-next-line no-console
           console.error(rootOrError.error);
         }

--- a/workspaces/rcx/demo/index.tsx
+++ b/workspaces/rcx/demo/index.tsx
@@ -154,7 +154,7 @@ const Page: RCXComponent = () => {
   });
 
   useOnMount(() => {
-    window.setTimeout(() => {
+    globalThis.setTimeout(() => {
       reactive.isMounted = false;
     }, 1000);
   });
@@ -377,7 +377,7 @@ const App = () => {
 const root = createRoot(document.body);
 
 if ('error' in root) {
-  if (window.console && typeof window.console.error === 'function') {
+  if (globalThis.console && typeof globalThis.console.error === 'function') {
     // eslint-disable-next-line no-console
     console.error(root.error);
   }

--- a/workspaces/rcx/src/hooks/use-loop.ts
+++ b/workspaces/rcx/src/hooks/use-loop.ts
@@ -4,8 +4,8 @@ export const useLoop = (callback: () => void) => {
   const unreactive = useUnreactive<{ raf: number | null }>({ raf: null });
 
   if (typeof unreactive.raf === 'number') {
-    window.cancelAnimationFrame(unreactive.raf);
+    globalThis.cancelAnimationFrame(unreactive.raf);
   }
 
-  unreactive.raf = window.requestAnimationFrame(callback);
+  unreactive.raf = globalThis.requestAnimationFrame(callback);
 };

--- a/workspaces/rcx/src/hooks/use-window-size.ts
+++ b/workspaces/rcx/src/hooks/use-window-size.ts
@@ -3,20 +3,20 @@ import { useReactive } from './use-state.js';
 
 export const useWindowSize = () => {
   const size = useReactive({
-    width: window.innerWidth,
-    height: window.innerHeight,
+    width: globalThis.innerWidth,
+    height: globalThis.innerHeight,
   });
 
   useOnMount(() => {
     const onResize = () => {
-      size.width = window.innerWidth;
-      size.height = window.innerHeight;
+      size.width = globalThis.innerWidth;
+      size.height = globalThis.innerHeight;
     };
 
-    window.addEventListener('resize', onResize);
+    globalThis.addEventListener('resize', onResize);
 
     return () => {
-      window.removeEventListener('resize', onResize);
+      globalThis.removeEventListener('resize', onResize);
     };
   });
 

--- a/workspaces/rcx/src/root.ts
+++ b/workspaces/rcx/src/root.ts
@@ -20,7 +20,7 @@ export const createRoot = (container: HTMLElement): CreateRootResult => {
   if (!ctx2d) {
     const errorMessage = 'CanvasRenderingContext2D not supported';
 
-    if (window.console && typeof window.console.error === 'function') {
+    if (globalThis.console && typeof globalThis.console.error === 'function') {
       // eslint-disable-next-line no-console
       console.error(errorMessage);
     }
@@ -38,10 +38,10 @@ export const createRoot = (container: HTMLElement): CreateRootResult => {
 
   const renderRoot = () => {
     if (typeof raf === 'number') {
-      window.cancelAnimationFrame(raf);
+      globalThis.cancelAnimationFrame(raf);
     }
 
-    raf = window.requestAnimationFrame(() => {
+    raf = globalThis.requestAnimationFrame(() => {
       // eslint-disable-next-line no-self-assign
       canvas.width = canvas.width;
       if (rootElement) {
@@ -57,7 +57,7 @@ export const createRoot = (container: HTMLElement): CreateRootResult => {
     rootElement = undefined;
 
     if (typeof raf === 'number') {
-      window.cancelAnimationFrame(raf);
+      globalThis.cancelAnimationFrame(raf);
     }
 
     // eslint-disable-next-line no-self-assign

--- a/workspaces/rcx/src/utils/get-recommended-pixel-ratio.ts
+++ b/workspaces/rcx/src/utils/get-recommended-pixel-ratio.ts
@@ -1,2 +1,2 @@
 export const getRecommendedPixelRatio = () =>
-  window.devicePixelRatio >= 2 ? 2 : 1;
+  globalThis.devicePixelRatio >= 2 ? 2 : 1;


### PR DESCRIPTION
- Prevent accessing `window` and `error` globally
- Swap usage of `window` for `globalThis`